### PR TITLE
Allow incremental deployment

### DIFF
--- a/day-1/README.md
+++ b/day-1/README.md
@@ -13,6 +13,15 @@ make install-hoprd env=staging debug=true limit=hetzner-staging-alpha-4
 make restart env=staging clean=false limit=hetzner-staging-alpha-11
 make restart env=staging clean=true
 
+
+make restart env=prod limit=entry_node_a
+make restart env=prod limit=exit_node_a
+make restart env=prod limit=entry_node_b
+make restart env=prod limit=exit_node_b
+make restart env=prod limit=entry_node_c
+make restart env=prod limit=exit_node_c
+
+
 make encrypt env=staging
 make decrypt env=staging
 make show env=staging

--- a/day-1/README.md
+++ b/day-1/README.md
@@ -14,16 +14,23 @@ make restart env=staging clean=false limit=hetzner-staging-alpha-11
 make restart env=staging clean=true
 
 
-make restart env=prod limit=entry_node_a
-make restart env=prod limit=exit_node_a
-make restart env=prod limit=entry_node_b
-make restart env=prod limit=exit_node_b
-make restart env=prod limit=entry_node_c
-make restart env=prod limit=exit_node_c
-
-
 make encrypt env=staging
 make decrypt env=staging
 make show env=staging
 
 ```
+
+
+## Rollout Deployment
+
+These commands show the sequence for a rollout deployment of new versions:
+````
+make restart env=prod limit=entry_node_a
+make restart env=prod limit=exit_node_a
+sleep 300
+make restart env=prod limit=entry_node_b
+make restart env=prod limit=exit_node_b
+sleep 300
+make restart env=prod limit=entry_node_c
+make restart env=prod limit=exit_node_c
+````

--- a/day-1/inventories/prod/inventory.yaml
+++ b/day-1/inventories/prod/inventory.yaml
@@ -66,7 +66,6 @@ all:
             production-19:
         exit_node_c:
           hosts:
-            production-19:
             production-20:
             production-21:
             production-22:

--- a/day-1/inventories/prod/inventory.yaml
+++ b/day-1/inventories/prod/inventory.yaml
@@ -15,6 +15,23 @@ all:
         production-7:
         production-8:
         production-9:
+      children:
+        entry_node_a:
+          hosts:
+            production-0:
+            production-1:
+            production-2:
+            production-3:
+        entry_node_b:
+          hosts:
+            production-4:
+            production-5:
+            production-6:
+        entry_node_c:
+          hosts:
+            production-7:
+            production-8:
+            production-9:
     exit_node:
       hosts:
         production-10:
@@ -32,6 +49,29 @@ all:
         production-22:
         production-23:
         production-24:
+      children:
+        exit_node_a:
+          hosts:
+            production-10:
+            production-11:
+            production-12:
+            production-13:
+            production-14:
+        exit_node_b:
+          hosts:
+            production-15:
+            production-16:
+            production-17:
+            production-18:
+            production-19:
+        exit_node_c:
+          hosts:
+            production-19:
+            production-20:
+            production-21:
+            production-22:
+            production-23:
+            production-24:
   hosts:
     production-0:
     production-1:

--- a/day-1/restart.yaml
+++ b/day-1/restart.yaml
@@ -4,6 +4,8 @@
   become: true
   vars:
     clean_db: false
+  tags:
+    - entry_node
   tasks:
     - name: Stop Hoprd service
       ansible.builtin.service:
@@ -21,6 +23,12 @@
         name: "hoprd.service"
         state: started
         enabled: true
+
+    - name: Pause for 5 minutes allow hoprd start
+      ansible.builtin.pause:
+        minutes: 5
+      tags:
+        - pause
 
 - name: Restart exit Nodes
   gather_facts: false

--- a/day-1/restart.yaml
+++ b/day-1/restart.yaml
@@ -1,6 +1,6 @@
 - name: Restart entry Nodes
   gather_facts: false
-  hosts: entry_node_a,entry_node_b,entry_node_c,exit_node_a,exit_node_b,exit_node_c
+  hosts: entry_node,exit_node,entry_node_a,entry_node_b,entry_node_c,exit_node_a,exit_node_b,exit_node_c
   become: true
   vars:
     clean_db: false
@@ -24,7 +24,7 @@
 
 - name: Restart exit Nodes
   gather_facts: false
-  hosts: exit_node_a,exit_node_b,exit_node_c
+  hosts: exit_node,exit_node_a,exit_node_b,exit_node_c
   become: true
   tasks:
     - name: Restart Exit Node service

--- a/day-1/restart.yaml
+++ b/day-1/restart.yaml
@@ -24,9 +24,9 @@
         state: started
         enabled: true
 
-    - name: Pause for 5 minutes allow hoprd start
+    - name: Pause for 3 minutes allow hoprd start
       ansible.builtin.pause:
-        minutes: 5
+        minutes: 3
       tags:
         - pause
 

--- a/day-1/restart.yaml
+++ b/day-1/restart.yaml
@@ -1,6 +1,6 @@
 - name: Restart entry Nodes
   gather_facts: false
-  hosts: entry_node,exit_node
+  hosts: entry_node_a,entry_node_b,entry_node_c,exit_node_a,exit_node_b,exit_node_c
   become: true
   vars:
     clean_db: false
@@ -24,7 +24,7 @@
 
 - name: Restart exit Nodes
   gather_facts: false
-  hosts: exit_node
+  hosts: exit_node_a,exit_node_b,exit_node_c
   become: true
   tasks:
     - name: Restart Exit Node service


### PR DESCRIPTION
New Makefile targets can be used:
````
make restart env=prod limit=entry_node_a
make restart env=prod limit=exit_node_a
make restart env=prod limit=entry_node_b
make restart env=prod limit=exit_node_b
make restart env=prod limit=entry_node_c
make restart env=prod limit=exit_node_c
````